### PR TITLE
Fix OverallVerdict struct

### DIFF
--- a/types.go
+++ b/types.go
@@ -142,7 +142,7 @@ type Verdict struct {
 
 type OverallVerdict struct {
 	Verdict
-	Brands []string `json:"brands"`
+	Brands []Brand `json:"brands"`
 }
 
 type EnginesVerdict struct {

--- a/types.go
+++ b/types.go
@@ -141,8 +141,12 @@ type Verdict struct {
 }
 
 type OverallVerdict struct {
-	Verdict
-	Brands []Brand `json:"brands"`
+	Score       int      `json:"score"`
+	Categories  []string `json:"categories"`
+	Brands      []string  `json:"brands"`
+	Tags        []string `json:"tags"`
+	Malicious   bool     `json:"malicious"`
+	HasVerdicts bool     `json:"hasVerdicts"`
 }
 
 type EnginesVerdict struct {


### PR DESCRIPTION
I came across the following error when trying to PR ([phish-report#221](https://github.com/phish-report/IOK/pull/221)) a new IOK rule on the IOK repository.

```
2023/09/17 01:27:30 Rule indicators/postalfurious-f25f698b.yml failed to verify ❌  failed to get IOK input c4f93aaf-833b-4ca9-86c9-7be303bd386c: internal: json: cannot unmarshal string into Go struct field Verdict.verdicts.overall.brands of type urlscanio.Brand
```
From what I can understand with my basic knowledge of Go, the structs seem to have overlapped when the `Verdict` struct was used as a template for the `OverallVerdict` struct, leading to the parent struct's (`Verdict`) brand field being used as the data type when parsing the `overall.brands` field of the URLScan API response.

This PR should fix the `OverallVerdict` struct so that it uses the appropriate data type for the `brands` field and does not use the `Verdict` struct as a template as the brands fields in both are different.